### PR TITLE
Removed --disable-sysclk-lwla flag from ./configure

### DIFF
--- a/libsigrok.rb
+++ b/libsigrok.rb
@@ -24,7 +24,7 @@ class Libsigrok < Formula
     if build.head?
       system "./autogen.sh"
     end
-    system "./configure", "--prefix=#{prefix}", "--disable-java", "--disable-sysclk-lwla"
+    system "./configure", "--prefix=#{prefix}", "--disable-java"
     system "make", "install"
     system "ln", "-s", "/usr/local/share/", "#{prefix}/share"
   end


### PR DESCRIPTION
On line 27, I have removed the flag "--disable-sysclk-lwla" because I actually needed this and it set me back some hours trying to understand why my device (lwla1034) wouldn't work.